### PR TITLE
Static schedule loading

### DIFF
--- a/inky-mbta-tracker/mbta_client.py
+++ b/inky-mbta-tracker/mbta_client.py
@@ -100,6 +100,8 @@ class Watcher:
                         await self.queue_schedule_event(
                             item, "reset", queue, transit_time_min, session
                         )
+                    if len(prediction) == 0:
+                        await self.save_schedule(transit_time_min, queue, session)
                 case "add":
                     prediction = PredictionResource.model_validate_json(
                         data, strict=False


### PR DESCRIPTION
If a stop is being shuttled then there usually is no real-time tracking on the API level. Therefore, if a `reset` event is returned with 0 items included, the tracker will load the static schedule API endpoint instead to try and fetch any info.